### PR TITLE
Add supported version to schema title and schema list

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -54,10 +54,15 @@ function buildSchemasList(listFile) {
     function (file, enc, done) {
       if (file.isNull() || file.isStream()) return done();
       const schemaName = file.relative.replace(/\.json$/, "");
+      const schema = JSON.parse(file.contents);
+      const version = schema.title.match(/ v([0-9]+\.[0-9]+\.[0-9]+(?:-\w+)?)/)[1];
+
       schemas[schemaName] = {
         "name": schemaName,
         "file": file.relative,
+        "version": version,
       };
+
       first = first || schemas[schemaName];
       done();
     },

--- a/meta-schema.json
+++ b/meta-schema.json
@@ -9,7 +9,7 @@
     "$schema": { "enum": ["http://json-schema.org/draft-04/schema#"] },
     "title": {
       "type": "string",
-      "pattern": "^textlint-rule-[a-zA-Z0-9_-]+ configuration$"
+      "pattern": "^textlint-rule-[a-zA-Z0-9_-]+ v[0-9\\.]+ configuration$"
     },
     "oneOf": {
       "$ref": "#/definitions/ruleConfigOneOf"

--- a/meta-schema.json
+++ b/meta-schema.json
@@ -75,14 +75,11 @@
                   "additionalProperties": {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["title", "oneOf"],
+                    "required": ["$ref", "default"],
                     "properties": {
-                      "title": {
+                      "$ref": {
                         "type": "string",
-                        "pattern": "^textlint-rule-[a-zA-Z0-9_-]+ configuration$"
-                      },
-                      "oneOf": {
-                        "$ref": "#/definitions/ruleConfigOneOf"
+                        "pattern": "^textlint-rule-[a-zA-Z0-9_-]+\\.json#$"
                       },
                       "default": {
                         "type": "boolean"

--- a/package.json
+++ b/package.json
@@ -55,12 +55,12 @@
     "gulp-load-plugins": "^1.2.2",
     "gulp-mocha": "^2.2.0",
     "gulp-sequence": "^0.4.5",
+    "gulp-tv4": "^0.1.0",
     "gulp-util": "^3.0.7",
     "power-assert": "^1.4.0",
     "semantic-release": "^4.3.5",
     "sr-condition-wercker": "^1.0.2",
     "through2": "^2.0.1",
-    "validate-commit-msg": "^2.6.1",
-    "z-schema": "^3.17.0"
+    "validate-commit-msg": "^2.6.1"
   }
 }

--- a/schemas-list.json
+++ b/schemas-list.json
@@ -1,158 +1,197 @@
 {
   "textlint-rule-alex": {
     "name": "textlint-rule-alex",
-    "file": "textlint-rule-alex.json"
+    "file": "textlint-rule-alex.json",
+    "version": "1.0.1"
   },
   "textlint-rule-common-misspellings": {
     "name": "textlint-rule-common-misspellings",
-    "file": "textlint-rule-common-misspellings.json"
+    "file": "textlint-rule-common-misspellings.json",
+    "version": "1.0.1"
   },
   "textlint-rule-editorconfig": {
     "name": "textlint-rule-editorconfig",
-    "file": "textlint-rule-editorconfig.json"
+    "file": "textlint-rule-editorconfig.json",
+    "version": "1.0.2"
   },
   "textlint-rule-en-max-word-count": {
     "name": "textlint-rule-en-max-word-count",
-    "file": "textlint-rule-en-max-word-count.json"
+    "file": "textlint-rule-en-max-word-count.json",
+    "version": "1.0.0"
   },
   "textlint-rule-general-novel-style-ja": {
     "name": "textlint-rule-general-novel-style-ja",
-    "file": "textlint-rule-general-novel-style-ja.json"
+    "file": "textlint-rule-general-novel-style-ja.json",
+    "version": "1.3.0"
   },
   "textlint-rule-ginger": {
     "name": "textlint-rule-ginger",
-    "file": "textlint-rule-ginger.json"
+    "file": "textlint-rule-ginger.json",
+    "version": "0.1.6"
   },
   "textlint-rule-incremental-headers": {
     "name": "textlint-rule-incremental-headers",
-    "file": "textlint-rule-incremental-headers.json"
+    "file": "textlint-rule-incremental-headers.json",
+    "version": "0.2.0"
   },
   "textlint-rule-ja-yahoo-kousei": {
     "name": "textlint-rule-ja-yahoo-kousei",
-    "file": "textlint-rule-ja-yahoo-kousei.json"
+    "file": "textlint-rule-ja-yahoo-kousei.json",
+    "version": "1.0.2"
   },
   "textlint-rule-max-appearence-count-of-words": {
     "name": "textlint-rule-max-appearence-count-of-words",
-    "file": "textlint-rule-max-appearence-count-of-words.json"
+    "file": "textlint-rule-max-appearence-count-of-words.json",
+    "version": "1.0.1"
   },
   "textlint-rule-max-comma": {
     "name": "textlint-rule-max-comma",
-    "file": "textlint-rule-max-comma.json"
+    "file": "textlint-rule-max-comma.json",
+    "version": "1.0.1"
   },
   "textlint-rule-max-kanji-continuous-len": {
     "name": "textlint-rule-max-kanji-continuous-len",
-    "file": "textlint-rule-max-kanji-continuous-len.json"
+    "file": "textlint-rule-max-kanji-continuous-len.json",
+    "version": "1.0.1"
   },
   "textlint-rule-max-length-of-title": {
     "name": "textlint-rule-max-length-of-title",
-    "file": "textlint-rule-max-length-of-title.json"
+    "file": "textlint-rule-max-length-of-title.json",
+    "version": "1.0.1"
   },
   "textlint-rule-max-number-of-lines": {
     "name": "textlint-rule-max-number-of-lines",
-    "file": "textlint-rule-max-number-of-lines.json"
+    "file": "textlint-rule-max-number-of-lines.json",
+    "version": "1.0.2"
   },
   "textlint-rule-max-ten": {
     "name": "textlint-rule-max-ten",
-    "file": "textlint-rule-max-ten.json"
+    "file": "textlint-rule-max-ten.json",
+    "version": "2.0.1"
   },
   "textlint-rule-ng-word": {
     "name": "textlint-rule-ng-word",
-    "file": "textlint-rule-ng-word.json"
+    "file": "textlint-rule-ng-word.json",
+    "version": "1.0.0"
   },
   "textlint-rule-no-dead-link": {
     "name": "textlint-rule-no-dead-link",
-    "file": "textlint-rule-no-dead-link.json"
+    "file": "textlint-rule-no-dead-link.json",
+    "version": "0.2.0"
   },
   "textlint-rule-no-double-negative-ja": {
     "name": "textlint-rule-no-double-negative-ja",
-    "file": "textlint-rule-no-double-negative-ja.json"
+    "file": "textlint-rule-no-double-negative-ja.json",
+    "version": "1.0.4"
   },
   "textlint-rule-no-doubled-conjunction": {
     "name": "textlint-rule-no-doubled-conjunction",
-    "file": "textlint-rule-no-doubled-conjunction.json"
+    "file": "textlint-rule-no-doubled-conjunction.json",
+    "version": "1.0.1"
   },
   "textlint-rule-no-doubled-conjunctive-particle-ga": {
     "name": "textlint-rule-no-doubled-conjunctive-particle-ga",
-    "file": "textlint-rule-no-doubled-conjunctive-particle-ga.json"
+    "file": "textlint-rule-no-doubled-conjunctive-particle-ga.json",
+    "version": "1.0.2"
   },
   "textlint-rule-no-doubled-joshi": {
     "name": "textlint-rule-no-doubled-joshi",
-    "file": "textlint-rule-no-doubled-joshi.json"
+    "file": "textlint-rule-no-doubled-joshi.json",
+    "version": "3.2.1"
   },
   "textlint-rule-no-dropping-the-ra": {
     "name": "textlint-rule-no-dropping-the-ra",
-    "file": "textlint-rule-no-dropping-the-ra.json"
+    "file": "textlint-rule-no-dropping-the-ra.json",
+    "version": "1.0.2"
   },
   "textlint-rule-no-exclamation-question-mark": {
     "name": "textlint-rule-no-exclamation-question-mark",
-    "file": "textlint-rule-no-exclamation-question-mark.json"
+    "file": "textlint-rule-no-exclamation-question-mark.json",
+    "version": "1.0.2"
   },
   "textlint-rule-no-hankaku-kana": {
     "name": "textlint-rule-no-hankaku-kana",
-    "file": "textlint-rule-no-hankaku-kana.json"
+    "file": "textlint-rule-no-hankaku-kana.json",
+    "version": "1.0.1"
   },
   "textlint-rule-no-mix-dearu-desumasu": {
     "name": "textlint-rule-no-mix-dearu-desumasu",
-    "file": "textlint-rule-no-mix-dearu-desumasu.json"
+    "file": "textlint-rule-no-mix-dearu-desumasu.json",
+    "version": "2.2.1"
   },
   "textlint-rule-no-nfd": {
     "name": "textlint-rule-no-nfd",
-    "file": "textlint-rule-no-nfd.json"
+    "file": "textlint-rule-no-nfd.json",
+    "version": "1.0.1"
   },
   "textlint-rule-no-start-duplicated-conjunction": {
     "name": "textlint-rule-no-start-duplicated-conjunction",
-    "file": "textlint-rule-no-start-duplicated-conjunction.json"
+    "file": "textlint-rule-no-start-duplicated-conjunction.json",
+    "version": "1.0.7"
   },
   "textlint-rule-no-todo": {
     "name": "textlint-rule-no-todo",
-    "file": "textlint-rule-no-todo.json"
+    "file": "textlint-rule-no-todo.json",
+    "version": "2.0.0"
   },
   "textlint-rule-preset-japanese": {
     "name": "textlint-rule-preset-japanese",
-    "file": "textlint-rule-preset-japanese.json"
+    "file": "textlint-rule-preset-japanese.json",
+    "version": "1.2.0"
   },
   "textlint-rule-preset-jtf-style": {
     "name": "textlint-rule-preset-jtf-style",
-    "file": "textlint-rule-preset-jtf-style.json"
+    "file": "textlint-rule-preset-jtf-style.json",
+    "version": "2.2.0"
   },
   "textlint-rule-prh": {
     "name": "textlint-rule-prh",
-    "file": "textlint-rule-prh.json"
+    "file": "textlint-rule-prh.json",
+    "version": "3.0.1"
   },
   "textlint-rule-report-node-types": {
     "name": "textlint-rule-report-node-types",
-    "file": "textlint-rule-report-node-types.json"
+    "file": "textlint-rule-report-node-types.json",
+    "version": "1.0.1"
   },
   "textlint-rule-rousseau": {
     "name": "textlint-rule-rousseau",
-    "file": "textlint-rule-rousseau.json"
+    "file": "textlint-rule-rousseau.json",
+    "version": "1.4.1"
   },
   "textlint-rule-sentence-length": {
     "name": "textlint-rule-sentence-length",
-    "file": "textlint-rule-sentence-length.json"
+    "file": "textlint-rule-sentence-length.json",
+    "version": "1.0.4"
   },
   "textlint-rule-sjsj": {
     "name": "textlint-rule-sjsj",
-    "file": "textlint-rule-sjsj.json"
+    "file": "textlint-rule-sjsj.json",
+    "version": "1.0.5"
   },
   "textlint-rule-spellcheck-tech-word": {
     "name": "textlint-rule-spellcheck-tech-word",
-    "file": "textlint-rule-spellcheck-tech-word.json"
+    "file": "textlint-rule-spellcheck-tech-word.json",
+    "version": "5.0.0"
   },
   "textlint-rule-spellchecker": {
     "name": "textlint-rule-spellchecker",
-    "file": "textlint-rule-spellchecker.json"
+    "file": "textlint-rule-spellchecker.json",
+    "version": "0.1.4"
   },
   "textlint-rule-unexpanded-acronym": {
     "name": "textlint-rule-unexpanded-acronym",
-    "file": "textlint-rule-unexpanded-acronym.json"
+    "file": "textlint-rule-unexpanded-acronym.json",
+    "version": "1.2.1"
   },
   "textlint-rule-web-plus-db": {
     "name": "textlint-rule-web-plus-db",
-    "file": "textlint-rule-web-plus-db.json"
+    "file": "textlint-rule-web-plus-db.json",
+    "version": "1.1.5"
   },
   "textlint-rule-write-good": {
     "name": "textlint-rule-write-good",
-    "file": "textlint-rule-write-good.json"
+    "file": "textlint-rule-write-good.json",
+    "version": "0.1.4"
   }
 }

--- a/schemas/textlint-rule-alex.json
+++ b/schemas/textlint-rule-alex.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-alex configuration",
+  "title": "textlint-rule-alex v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-common-misspellings.json
+++ b/schemas/textlint-rule-common-misspellings.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-common-misspellings configuration",
+  "title": "textlint-rule-common-misspellings v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-editorconfig.json
+++ b/schemas/textlint-rule-editorconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-editorconfig configuration",
+  "title": "textlint-rule-editorconfig v1.0.2 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-en-max-word-count.json
+++ b/schemas/textlint-rule-en-max-word-count.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-en-max-word-count configuration",
+  "title": "textlint-rule-en-max-word-count v1.0.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-general-novel-style-ja.json
+++ b/schemas/textlint-rule-general-novel-style-ja.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-general-novel-style-ja configuration",
+  "title": "textlint-rule-general-novel-style-ja v1.3.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-ginger.json
+++ b/schemas/textlint-rule-ginger.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-ginger configuration",
+  "title": "textlint-rule-ginger v0.1.6 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-incremental-headers.json
+++ b/schemas/textlint-rule-incremental-headers.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-incremental-headers configuration",
+  "title": "textlint-rule-incremental-headers v0.2.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-ja-yahoo-kousei.json
+++ b/schemas/textlint-rule-ja-yahoo-kousei.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-ja-yahoo-kousei configuration",
+  "title": "textlint-rule-ja-yahoo-kousei v1.0.2 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-max-appearence-count-of-words.json
+++ b/schemas/textlint-rule-max-appearence-count-of-words.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-max-appearence-count-of-words configuration",
+  "title": "textlint-rule-max-appearence-count-of-words v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-max-comma.json
+++ b/schemas/textlint-rule-max-comma.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-max-comma configuration",
+  "title": "textlint-rule-max-comma v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-max-kanji-continuous-len.json
+++ b/schemas/textlint-rule-max-kanji-continuous-len.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-max-kanji-continuous-len configuration",
+  "title": "textlint-rule-max-kanji-continuous-len v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-max-length-of-title.json
+++ b/schemas/textlint-rule-max-length-of-title.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-max-length-of-title configuration",
+  "title": "textlint-rule-max-length-of-title v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-max-number-of-lines.json
+++ b/schemas/textlint-rule-max-number-of-lines.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-max-number-of-lines configuration",
+  "title": "textlint-rule-max-number-of-lines v1.0.2 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-max-ten.json
+++ b/schemas/textlint-rule-max-ten.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-max-ten configuration",
+  "title": "textlint-rule-max-ten v2.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-ng-word.json
+++ b/schemas/textlint-rule-ng-word.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-ng-word configuration",
+  "title": "textlint-rule-ng-word v1.0.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-dead-link.json
+++ b/schemas/textlint-rule-no-dead-link.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-dead-link configuration",
+  "title": "textlint-rule-no-dead-link v0.2.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-double-negative-ja.json
+++ b/schemas/textlint-rule-no-double-negative-ja.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-double-negative-ja configuration",
+  "title": "textlint-rule-no-double-negative-ja v1.0.4 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-doubled-conjunction.json
+++ b/schemas/textlint-rule-no-doubled-conjunction.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-doubled-conjunction configuration",
+  "title": "textlint-rule-no-doubled-conjunction v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-doubled-conjunctive-particle-ga.json
+++ b/schemas/textlint-rule-no-doubled-conjunctive-particle-ga.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-doubled-conjunctive-particle-ga configuration",
+  "title": "textlint-rule-no-doubled-conjunctive-particle-ga v1.0.2 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-doubled-joshi.json
+++ b/schemas/textlint-rule-no-doubled-joshi.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-doubled-joshi configuration",
+  "title": "textlint-rule-no-doubled-joshi v3.2.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-dropping-the-ra.json
+++ b/schemas/textlint-rule-no-dropping-the-ra.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-dropping-the-ra configuration",
+  "title": "textlint-rule-no-dropping-the-ra v1.0.2 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-exclamation-question-mark.json
+++ b/schemas/textlint-rule-no-exclamation-question-mark.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-exclamation-question-mark configuration",
+  "title": "textlint-rule-no-exclamation-question-mark v1.0.2 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-hankaku-kana.json
+++ b/schemas/textlint-rule-no-hankaku-kana.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-hankaku-kana configuration",
+  "title": "textlint-rule-no-hankaku-kana v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-mix-dearu-desumasu.json
+++ b/schemas/textlint-rule-no-mix-dearu-desumasu.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-mix-dearu-desumasu configuration",
+  "title": "textlint-rule-no-mix-dearu-desumasu v2.2.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-mix-dearu-desumasu.json
+++ b/schemas/textlint-rule-no-mix-dearu-desumasu.json
@@ -7,6 +7,24 @@
   }, {
     "type": "object",
     "properties": {
+      "preferInHeader": {
+        "title": "Preferred style in header",
+        "type": "string",
+        "enum": ["", "である", "ですます"],
+        "default": ""
+      },
+      "preferInBody": {
+        "title": "Preferred style in body",
+        "type": "string",
+        "enum": ["", "である", "ですます"],
+        "default": ""
+      },
+      "preferInList": {
+        "title": "Preferred style in list",
+        "type": "string",
+        "enum": ["", "である", "ですます"],
+        "default": ""
+      },
       "severity": {
         "title": "Severity of lint messages",
         "type": "string",

--- a/schemas/textlint-rule-no-nfd.json
+++ b/schemas/textlint-rule-no-nfd.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-nfd configuration",
+  "title": "textlint-rule-no-nfd v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-start-duplicated-conjunction.json
+++ b/schemas/textlint-rule-no-start-duplicated-conjunction.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-start-duplicated-conjunction configuration",
+  "title": "textlint-rule-no-start-duplicated-conjunction v1.0.7 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-no-todo.json
+++ b/schemas/textlint-rule-no-todo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-no-todo configuration",
+  "title": "textlint-rule-no-todo v2.0.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-preset-japanese.json
+++ b/schemas/textlint-rule-preset-japanese.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-preset-japanese configuration",
+  "title": "textlint-rule-preset-japanese v1.2.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-preset-japanese.json
+++ b/schemas/textlint-rule-preset-japanese.json
@@ -8,163 +8,35 @@
     "type": "object",
     "properties": {
       "max-ten": {
-        "title": "textlint-rule-max-ten configuration",
-        "oneOf": [{
-          "title": "Enable this rule with default options",
-          "type": "boolean"
-        }, {
-          "type": "object",
-          "properties": {
-            "max": {
-              "title": "Maximum number of \"、\" allowed in a sentence",
-              "type": "integer",
-              "minimum": 1,
-              "default": 3
-            },
-            "strict": {
-              "title": "Strict check",
-              "type": "boolean",
-              "default": false
-            },
-            "severity": {
-              "title": "Severity of lint messages",
-              "type": "string",
-              "enum": ["error", "warning", "info"],
-              "default": "error"
-            }
-          }
-        }],
+        "$ref": "textlint-rule-max-ten.json#",
+        "default": true
+      },
+      "no-doubled-conjunctive-particle-ga": {
+        "$ref": "textlint-rule-no-doubled-conjunctive-particle-ga.json#",
+        "default": true
+      },
+      "no-doubled-conjunction": {
+        "$ref": "textlint-rule-no-doubled-conjunction.json#",
         "default": true
       },
       "no-double-negative-ja": {
-        "title": "textlint-rule-no-double-negative-ja configuration",
-        "oneOf": [{
-          "title": "Enable this rule with default options",
-          "type": "boolean"
-        }, {
-          "type": "object",
-          "properties": {
-            "severity": {
-              "title": "Severity of lint messages",
-              "type": "string",
-              "enum": ["error", "warning", "info"],
-              "default": "error"
-            }
-          }
-        }],
+        "$ref": "textlint-rule-no-double-negative-ja.json#",
         "default": true
       },
       "no-doubled-joshi": {
-        "title": "textlint-rule-no-doubled-joshi configuration",
-        "oneOf": [{
-          "title": "Enable this rule with default options",
-          "type": "boolean"
-        }, {
-          "type": "object",
-          "properties": {
-            "min_interval": {
-              "title": "Minimum interval of joshi",
-              "type": "integer",
-              "minimum": 1,
-              "default": 1
-            },
-            "strict": {
-              "title": "Strict check",
-              "type": "boolean",
-              "default": false
-            },
-            "severity": {
-              "title": "Severity of lint messages",
-              "type": "string",
-              "enum": ["error", "warning", "info"],
-              "default": "error"
-            }
-          }
-        }],
+        "$ref": "textlint-rule-no-doubled-joshi.json#",
         "default": true
       },
       "sentence-length": {
-        "title": "textlint-rule-sentence-length configuration",
-        "oneOf": [{
-          "title": "Enable this rule with default options",
-          "type": "boolean"
-        }, {
-          "type": "object",
-          "properties": {
-            "max": {
-              "title": "Maximum length of a sentence",
-              "type": "integer",
-              "minimum": 1,
-              "default": 100
-            },
-            "severity": {
-              "title": "Severity of lint messages",
-              "type": "string",
-              "enum": ["error", "warning", "info"],
-              "default": "error"
-            }
-          }
-        }],
-        "default": true
-      },
-      "no-start-duplicated-conjunction": {
-        "title": "textlint-rule-no-start-duplicated configuration",
-        "oneOf": [{
-          "title": "Enable this rule with default options",
-          "type": "boolean"
-        }, {
-          "type": "object",
-          "properties": {
-            "interval": {
-              "title": "Interval of sentences",
-              "type": "integer",
-              "minimum": 1,
-              "default": 2
-            },
-            "severity": {
-              "title": "Severity of lint messages",
-              "type": "string",
-              "enum": ["error", "warning", "info"],
-              "default": "error"
-            }
-          }
-        }],
+        "$ref": "textlint-rule-sentence-length.json#",
         "default": true
       },
       "spellcheck-tech-word": {
-        "title": "textlint-rule-spellcheck-tech-word configuration",
-        "oneOf": [{
-          "title": "Enable this rule with default options",
-          "type": "boolean"
-        }, {
-          "type": "object",
-          "properties": {
-            "severity": {
-              "title": "Severity of lint messages",
-              "type": "string",
-              "enum": ["error", "warning", "info"],
-              "default": "error"
-            }
-          }
-        }],
+        "$ref": "textlint-rule-spellcheck-tech-word.json#",
         "default": true
       },
       "no-mix-dearu-desumasu": {
-        "title": "textlint-rule-no-mix-dearu-desumasu configuration",
-        "oneOf": [{
-          "title": "Enable this rule with default options",
-          "type": "boolean"
-        }, {
-          "type": "object",
-          "properties": {
-            "severity": {
-              "title": "Severity of lint messages",
-              "type": "string",
-              "enum": ["error", "warning", "info"],
-              "default": "error"
-            }
-          }
-        }],
+        "$ref": "textlint-rule-no-mix-dearu-desumasu.json#",
         "default": true
       }
     }

--- a/schemas/textlint-rule-preset-jtf-style.json
+++ b/schemas/textlint-rule-preset-jtf-style.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-preset-jtf-style configuration",
+  "title": "textlint-rule-preset-jtf-style v2.2.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-prh.json
+++ b/schemas/textlint-rule-prh.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-prh configuration",
+  "title": "textlint-rule-prh v3.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-report-node-types.json
+++ b/schemas/textlint-rule-report-node-types.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-report-node-types configuration",
+  "title": "textlint-rule-report-node-types v1.0.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-rousseau.json
+++ b/schemas/textlint-rule-rousseau.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-rousseau configuration",
+  "title": "textlint-rule-rousseau v1.4.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-sentence-length.json
+++ b/schemas/textlint-rule-sentence-length.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-sentence-length configuration",
+  "title": "textlint-rule-sentence-length v1.0.4 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-sjsj.json
+++ b/schemas/textlint-rule-sjsj.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-sjsj configuration",
+  "title": "textlint-rule-sjsj v1.0.5 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-spellcheck-tech-word.json
+++ b/schemas/textlint-rule-spellcheck-tech-word.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-spellcheck-tech-word configuration",
+  "title": "textlint-rule-spellcheck-tech-word v5.0.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-spellchecker.json
+++ b/schemas/textlint-rule-spellchecker.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-spellchecker configuration",
+  "title": "textlint-rule-spellchecker v0.1.4 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-unexpanded-acronym.json
+++ b/schemas/textlint-rule-unexpanded-acronym.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-unexpanded-acronym configuration",
+  "title": "textlint-rule-unexpanded-acronym v1.2.1 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-web-plus-db.json
+++ b/schemas/textlint-rule-web-plus-db.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-web-plus-db configuration",
+  "title": "textlint-rule-web-plus-db v1.1.5 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"

--- a/schemas/textlint-rule-write-good.json
+++ b/schemas/textlint-rule-write-good.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-write-good configuration",
+  "title": "textlint-rule-write-good v0.1.4 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"


### PR DESCRIPTION
We put a supported version of textlint rule to its schema title and schema list.
- This could fail something which depends on the old schema title, so it is a breaking change.
- Update some schemas for the latest version.
- Use `$ref` to reference schemas of child rules in `textlint-rule-preset-japanse`.
