### PR TITLE
Update schemas for ignore-comments and ignore-node-types

### DIFF
--- a/schemas-list.json
+++ b/schemas-list.json
@@ -29,10 +29,15 @@
     "file": "textlint-rule-ginger.json",
     "version": "0.1.6"
   },
+  "textlint-rule-ignore-comments": {
+    "name": "textlint-rule-ignore-comments",
+    "file": "textlint-rule-ignore-comments.json",
+    "version": "1.1.0"
+  },
   "textlint-rule-ignore-node-types": {
     "name": "textlint-rule-ignore-node-types",
     "file": "textlint-rule-ignore-node-types.json",
-    "version": "0.2.0"
+    "version": "0.3.0"
   },
   "textlint-rule-incremental-headers": {
     "name": "textlint-rule-incremental-headers",

--- a/schemas/textlint-rule-ignore-comments.json
+++ b/schemas/textlint-rule-ignore-comments.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "textlint-rule-ignore-comments v1.1.0 configuration",
+  "oneOf": [{
+    "title": "Enable this rule with default options",
+    "type": "boolean"
+  }, {
+    "type": "object",
+    "properties": {
+      "enablingComment": {
+        "title": "Comment directive to enable linting",
+        "type": "string",
+        "minLength": 1,
+        "default": "textlint-enable"
+      },
+      "disablingComment": {
+        "title": "Comment directive to disable linting",
+        "type": "string",
+        "minLength": 1,
+        "default": "textlint-disable"
+      },
+      "severity": {
+        "title": "Severity of lint messages",
+        "type": "string",
+        "enum": ["error", "warning", "info"],
+        "default": "error"
+      }
+    }
+  }]
+}

--- a/schemas/textlint-rule-ignore-node-types.json
+++ b/schemas/textlint-rule-ignore-node-types.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-ignore-node-types v0.2.0 configuration",
+  "title": "textlint-rule-ignore-node-types v0.3.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"


### PR DESCRIPTION
- Add new schema for textlint-rule-ignore-comments v1.1.0
- Update schema version for textlint-rule-ignore-node-types v0.3.0 (no schema changes)

Closes #15, Closes #16
