### PR TITLE
Update schema for preset-japanese v1.3.0 and report-node-types v1.1.0

### DIFF
--- a/schemas-list.json
+++ b/schemas-list.json
@@ -172,7 +172,7 @@
   "textlint-rule-report-node-types": {
     "name": "textlint-rule-report-node-types",
     "file": "textlint-rule-report-node-types.json",
-    "version": "1.0.1"
+    "version": "1.1.0"
   },
   "textlint-rule-rousseau": {
     "name": "textlint-rule-rousseau",

--- a/schemas-list.json
+++ b/schemas-list.json
@@ -157,7 +157,7 @@
   "textlint-rule-preset-japanese": {
     "name": "textlint-rule-preset-japanese",
     "file": "textlint-rule-preset-japanese.json",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "textlint-rule-preset-jtf-style": {
     "name": "textlint-rule-preset-jtf-style",

--- a/schemas/textlint-rule-preset-japanese.json
+++ b/schemas/textlint-rule-preset-japanese.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-preset-japanese v1.2.0 configuration",
+  "title": "textlint-rule-preset-japanese v1.3.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"
@@ -37,6 +37,10 @@
       },
       "no-mix-dearu-desumasu": {
         "$ref": "textlint-rule-no-mix-dearu-desumasu.json#",
+        "default": true
+      },
+      "no-nfd": {
+        "$ref": "textlint-rule-no-nfd.json#",
         "default": true
       }
     }

--- a/schemas/textlint-rule-report-node-types.json
+++ b/schemas/textlint-rule-report-node-types.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "textlint-rule-report-node-types v1.0.1 configuration",
+  "title": "textlint-rule-report-node-types v1.1.0 configuration",
   "oneOf": [{
     "title": "Enable this rule with default options",
     "type": "boolean"


### PR DESCRIPTION
Update schemas for updated rules
- textlint-rule-preset-japanese v1.3.0 (#20)
- textlint-rule-report-node-types v1.1.0 (#21)
